### PR TITLE
fix: Provider-specific configuration from other eDNS instances are causing errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,6 @@ This is problematic because, even though we can create an `Endpoint` with no nam
 
 See mirceanton/external-dns-provider-mikrotik#166
 
-### Multiple provider-specific annotations
-
-In the case of multiple external-dns instances, each with a different provider (for example this one and the cloudflare one), there are problems with passing in annotations for provider-specific configuration. Due to a bug in the upstream external-dns, all annotations will be passed as provider-configuration.
-
-This will cause the webhook to complain that invalid provider-specific configuration entries have been passed and error out. While this check can be removed, it will cause external-dns to continuously detect a drift between the Endpoint and the DNS records in RouterOS, thus attempting a new reconcile at every loop. This is also not desired.
-
-See mirceanton/external-dns-provider-mikrotik#140 and kubernetes-sigs/external-dns#4951
-
 ## ⚙️ Configuration Options
 
 ### MikroTik Connection Configuration

--- a/example/ingress/sample.yaml
+++ b/example/ingress/sample.yaml
@@ -40,11 +40,12 @@ metadata:
   name: nginx-demo
   annotations:
     external-dns.alpha.kubernetes.io/hostname: "example.com"
-    external-dns.alpha.kubernetes.io/ttl: "60"
-    external-dns.alpha.kubernetes.io/webhook-comment: "This is a static DNS record created via ingress annotations!"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false" #? test for unknown PS configuration
+    # external-dns.alpha.kubernetes.io/ttl: "`60" #? Test for default ttl
+    # external-dns.alpha.kubernetes.io/webhook-comment: "This is a static DNS record created via ingress annotations!" #? test for default comment
     external-dns.alpha.kubernetes.io/webhook-address-list: "4.5.6.7"
     external-dns.alpha.kubernetes.io/webhook-match-subdomain: "false"
-    external-dns.alpha.kubernetes.io/webhook-disabled: "true"
+    external-dns.alpha.kubernetes.io/webhook-disabled: "false"
 spec:
   rules:
     - host: example.com

--- a/internal/mikrotik/record.go
+++ b/internal/mikrotik/record.go
@@ -152,11 +152,7 @@ func NewDNSRecord(endpoint *endpoint.Endpoint) (*DNSRecord, error) {
 			record.AddressList = providerSpecific.Value
 			log.Debugf("AddressList set to: %s", record.AddressList)
 		default:
-			return nil, fmt.Errorf(
-				"unsupported provider specific configuration '%s' for DNS Record of type %s",
-				providerSpecific.Name,
-				record.Type,
-			)
+			log.Debugf("Encountered unknown provider-specific configuration '%s: %s' for DNS Record of type %s", providerSpecific.Name, providerSpecific.Value, record.Type)
 		}
 	}
 

--- a/internal/mikrotik/record_test.go
+++ b/internal/mikrotik/record_test.go
@@ -1295,13 +1295,19 @@ func TestExternalDNSEndpointToDNSRecord(t *testing.T) {
 			endpoint: &endpoint.Endpoint{
 				DNSName:    "example.com",
 				RecordType: "TXT",
+				RecordTTL:  endpoint.TTL(5),
 				Targets:    endpoint.NewTargets("some text"),
 				ProviderSpecific: endpoint.ProviderSpecific{
 					{Name: "unsupported", Value: "value"},
 				},
 			},
-			expected:    nil,
-			expectError: true,
+			expected: &DNSRecord{
+				Name: "example.com",
+				Type: "TXT",
+				TTL:  "5s",
+				Text: "some text",
+			},
+			expectError: false,
 		},
 		{
 			name: "Setting match-subdomain via provider-specific",


### PR DESCRIPTION
Fixes #140 

In all fairness, that was really on me. I added the `return Error` when an unknown PS value was encountered 😅 