### PR TITLE
ci: don't pin tools to specific versions

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -30,6 +30,6 @@ jobs:
     with:
       dry-run: ${{ inputs.dry-run || github.event_name == 'pull_request' }}
       # renovate: depName=go datasource=golang-version
-      go-version: 1.24.1
+      go-version: stable
       # renovate: depName=goreleaser/goreleaser datasource=github-tags
-      goreleaser-version: v2.8.0
+      goreleaser-version: main

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,6 +25,6 @@ jobs:
     uses: mirceanton/reusable-workflows/.github/workflows/reusable-go-lint.yaml@09f31ab6340ce5651dc6c28512a82de6b2415fb9 # v3.8.2
     with:
       # renovate: depName=go datasource=golang-version
-      go-version: 1.24.1
+      go-version: stable
       # renovate: depName=golangci/golangci-lint datasource=github-tags
-      golangci-lint-version: v1.64.7
+      golangci-lint-version: main


### PR DESCRIPTION
this causes a lot of noise and churn with renovate.