### PR TITLE
chore(mise): switch goreleaser to github backend, bump to 2.18.0

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -4,7 +4,7 @@
 # =================================================================================================
 go = "1.27.0"
 golangci-lint = "2.13.1"
-"aqua:goreleaser/goreleaser" = "2.17.1"
+"github:goreleaser/goreleaser" = "2.18.0"
 "aqua:kubernetes/kubectl" = "1.33.1"
 
 

--- a/mise.lock
+++ b/mise.lock
@@ -39,52 +39,6 @@ checksum = "sha256:bba299f1877913979831543a008f2e104995d2ea4ac8f23d7f49c0444857d
 url = "https://github.com/derailed/k9s/releases/download/v0.51.0/k9s_Windows_amd64.zip"
 url_api = "https://api.github.com/repos/derailed/k9s/releases/assets/440224317"
 
-[[tools."aqua:goreleaser/goreleaser"]]
-version = "2.17.1"
-backend = "aqua:goreleaser/goreleaser"
-
-[tools."aqua:goreleaser/goreleaser"."platforms.linux-arm64"]
-checksum = "sha256:702f03769ac8bcb0e47839c82243cc614ae995633599a98c63062e13ea85f829"
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.17.1/goreleaser_Linux_arm64.tar.gz"
-url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/490565875"
-provenance = "github-attestations"
-
-[tools."aqua:goreleaser/goreleaser"."platforms.linux-arm64-musl"]
-checksum = "sha256:702f03769ac8bcb0e47839c82243cc614ae995633599a98c63062e13ea85f829"
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.17.1/goreleaser_Linux_arm64.tar.gz"
-url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/490565875"
-provenance = "github-attestations"
-
-[tools."aqua:goreleaser/goreleaser"."platforms.linux-x64"]
-checksum = "sha256:a99bbc7ae0d8d897b07c4c497a9b62f222558804715ef219d1af05a7e417bc80"
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.17.1/goreleaser_Linux_x86_64.tar.gz"
-url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/490565870"
-provenance = "github-attestations"
-
-[tools."aqua:goreleaser/goreleaser"."platforms.linux-x64-musl"]
-checksum = "sha256:a99bbc7ae0d8d897b07c4c497a9b62f222558804715ef219d1af05a7e417bc80"
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.17.1/goreleaser_Linux_x86_64.tar.gz"
-url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/490565870"
-provenance = "github-attestations"
-
-[tools."aqua:goreleaser/goreleaser"."platforms.macos-arm64"]
-checksum = "sha256:f49d4fe67d283b5b5130c380c983087dca0a4d4ec15b6637b18fe1ab096780d8"
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.17.1/goreleaser_Darwin_all.tar.gz"
-url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/490565848"
-provenance = "github-attestations"
-
-[tools."aqua:goreleaser/goreleaser"."platforms.macos-x64"]
-checksum = "sha256:f49d4fe67d283b5b5130c380c983087dca0a4d4ec15b6637b18fe1ab096780d8"
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.17.1/goreleaser_Darwin_all.tar.gz"
-url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/490565848"
-provenance = "github-attestations"
-
-[tools."aqua:goreleaser/goreleaser"."platforms.windows-x64"]
-checksum = "sha256:53314ce7cc16c3229f2d3b98a932c1618c427964eb2170a1efafbdfa862a556f"
-url = "https://github.com/goreleaser/goreleaser/releases/download/v2.17.1/goreleaser_Windows_x86_64.zip"
-url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/490565847"
-provenance = "github-attestations"
-
 [[tools."aqua:helm/helm"]]
 version = "4.2.2"
 backend = "aqua:helm/helm"
@@ -268,6 +222,7 @@ checksum = "sha256:aeec0a735f12d6313c5b4f295ac2f86e00b56571d241abe5aa0306b41f43e
 url = "https://github.com/caarlos0/svu/releases/download/v3.4.1/svu_3.4.1_darwin_all.tar.gz"
 url_api = "https://api.github.com/repos/caarlos0/svu/releases/assets/410001878"
 provenance = "github-attestations"
+provenance_verified = true
 
 [tools."github:caarlos0/svu"."platforms.macos-x64"]
 checksum = "sha256:aeec0a735f12d6313c5b4f295ac2f86e00b56571d241abe5aa0306b41f43efd7"
@@ -279,6 +234,53 @@ provenance = "github-attestations"
 checksum = "sha256:7f8d17beb8fbe4a5c6e232072e93a71c8338173dafd95eda898bd1838d12b14e"
 url = "https://github.com/caarlos0/svu/releases/download/v3.4.1/svu_3.4.1_windows_amd64.zip"
 url_api = "https://api.github.com/repos/caarlos0/svu/releases/assets/410001860"
+provenance = "github-attestations"
+
+[[tools."github:goreleaser/goreleaser"]]
+version = "2.18.0"
+backend = "github:goreleaser/goreleaser"
+
+[tools."github:goreleaser/goreleaser"."platforms.linux-arm64"]
+checksum = "sha256:1975566c9668e6f4247e6bb57656f21da13635c24d948ef47b1232e5c864a35b"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.18.0/goreleaser_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/526873789"
+provenance = "github-attestations"
+
+[tools."github:goreleaser/goreleaser"."platforms.linux-arm64-musl"]
+checksum = "sha256:1975566c9668e6f4247e6bb57656f21da13635c24d948ef47b1232e5c864a35b"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.18.0/goreleaser_Linux_arm64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/526873789"
+provenance = "github-attestations"
+
+[tools."github:goreleaser/goreleaser"."platforms.linux-x64"]
+checksum = "sha256:41cdf49b653784b03a08013dd99e382cd5d463049e915c2d818eaed182ae6197"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.18.0/goreleaser_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/526873785"
+provenance = "github-attestations"
+
+[tools."github:goreleaser/goreleaser"."platforms.linux-x64-musl"]
+checksum = "sha256:41cdf49b653784b03a08013dd99e382cd5d463049e915c2d818eaed182ae6197"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.18.0/goreleaser_Linux_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/526873785"
+provenance = "github-attestations"
+
+[tools."github:goreleaser/goreleaser"."platforms.macos-arm64"]
+checksum = "sha256:1c42b87cbce094a60f1a94dab0c71f640dbe4396fa5dc632b5c25bf14b1e88fc"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.18.0/goreleaser_Darwin_arm64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/526873829"
+provenance = "github-attestations"
+provenance_verified = true
+
+[tools."github:goreleaser/goreleaser"."platforms.macos-x64"]
+checksum = "sha256:c115f9ca07163d55885ba2276c5c2efebc95d60f7f7f69fe2dd6a54e97ac6db4"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.18.0/goreleaser_Darwin_x86_64.tar.gz"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/526873864"
+provenance = "github-attestations"
+
+[tools."github:goreleaser/goreleaser"."platforms.windows-x64"]
+checksum = "sha256:cbd0aeab833806b6c07e2d156c2c9baaffa6e3d1fb870071bf3efc9d9e5b4777"
+url = "https://github.com/goreleaser/goreleaser/releases/download/v2.18.0/goreleaser_Windows_x86_64.zip"
+url_api = "https://api.github.com/repos/goreleaser/goreleaser/releases/assets/526873786"
 provenance = "github-attestations"
 
 [[tools.go]]


### PR DESCRIPTION
## Summary
- Switches `goreleaser/goreleaser` from the `aqua:` mise backend to the `github:` backend and bumps it straight to `v2.18.0`.

## Why
`aqua:goreleaser/goreleaser@2.18.0` currently fails `mise install` in CI: aqua-registry expects GitHub artifact attestations signed by workflow `goreleaser/goreleaser/.github/workflows/release.yml`, but v2.18.0's release carries an attestation identity of `https://dotcom.releases.github.com` instead — a mismatch, not a transient propagation delay (confirmed still failing 9+ hours after the release). GoReleaser has shipped broken/mismatched release attestations before (see `goreleaser/goreleaser#6436` for v2.14.2), so this is a recurring risk with the `aqua:` backend for this specific tool.

Verified locally: `github:goreleaser/goreleaser@2.18.0` installs cleanly and its GitHub artifact attestations verify successfully — same binary, same release, different (working) verification path. This directly unblocks the currently-open Renovate PR for this bump, which is stuck on the `aqua:` failure and will be auto-closed as superseded once this merges.

## Test plan
- [ ] CI passes on this PR (goreleaser installs, all mise-dependent jobs run)
